### PR TITLE
WIP: Adding NDEF Signature Record

### DIFF
--- a/docs/records.rst
+++ b/docs/records.rst
@@ -17,4 +17,4 @@ known record types.
    records/handover
    records/bluetooth
    records/wifi
-
+   records/signature

--- a/docs/records/signature.rst
+++ b/docs/records/signature.rst
@@ -49,6 +49,7 @@ store and an option URI to the next certificate in the chain.
 
       The signature type used in the signature algorithm.
 
+      >>> import ndef
       >>> print('\n'.join([str(x[1]) for x in ndef.signature.SignatureRecord()._mapping_signature_type]))
       None
       RSASSA-PSS-1024
@@ -67,6 +68,7 @@ store and an option URI to the next certificate in the chain.
 
       The hash type used in the signature algorithm.
 
+      >>> import ndef
       >>> print("\n".join([str(x[1]) for x in ndef.signature.SignatureRecord()._mapping_hash_type]))
       SHA-256
 
@@ -83,6 +85,7 @@ store and an option URI to the next certificate in the chain.
 
       The format of the certificates in the chain.
 
+      >>> import ndef
       >>> print("\n".join([str(x[1]) for x in ndef.signature.SignatureRecord()._mapping_certificate_format]))
       X.509
       M2M
@@ -98,6 +101,7 @@ store and an option URI to the next certificate in the chain.
 
    This is default usage:
 
+   >>> import ndef
    >>> signature_record = ndef.SignatureRecord(None, 'SHA-256', b'', '', 'X.509', [], '')
 
    This is a full example creating records, signing them and verifying them:

--- a/docs/records/signature.rst
+++ b/docs/records/signature.rst
@@ -1,0 +1,147 @@
+.. -*- mode: rst; fill-column: 80 -*-
+
+Signature Record
+----------------
+
+The NDEF Signature Record is a well-known record type defined by the
+`NFC Forum`_. It contains three fields: a version field, a signature field and
+a certificate field.
+
+The version field is static. Currently this implementation only supports v2.0
+of the NDEF Signature Record.
+
+The signature field contains the signature type, the message hash type and
+either the signature itself or a URI to the signature.
+
+The certificate field contains the certificate format type, a certificate chain
+store and an option URI to the next certificate in the chain.
+
+.. class:: SignatureRecord(signature_type=None, hash_type='SHA-256', signature=b'', signature_uri='', certificate_format='X.509', certificate_store=[], certificate_uri='')
+
+   The `SignatureRecord` class decodes or encodes an NDEF Signature Record.
+
+   :param str signature_type: initial value for the `signature_type` attribute, default None
+   :param str hash_type: initial value for the `hash_type` attribute, default 'SHA-256'
+   :param bytes signature: initial value for the `signature` attribute, default b''
+   :param str signature_uri: initial value for the `signature_uri` attribute, default ''
+   :param str certificate_format: initial value for the `certificate_format` attribute, default 'X.509'
+   :param list certificate_store: initial value for the `certificate_store` attribute, default []
+   :param str certificate_uri: initial value for the `certificate_uri` attribute, default ''
+
+   .. attribute:: type
+
+      The Signature Record type is ``urn:nfc:wkt:Sig``.
+
+   .. attribute:: name
+
+      Value of the NDEF Record ID field, an empty `str` if not set.
+
+   .. attribute:: data
+
+      A `bytes` object containing the NDEF Record PAYLOAD encoded from the
+      current attributes.
+
+   .. attribute:: version
+
+      The version of the NDEF Signature Record.
+
+   .. attribute:: signature_type
+
+      The signature type used in the signature algorithm.
+
+      >>> print('\n'.join([str(x[1]) for x in ndef.signature.SignatureRecord()._mapping_signature_type]))
+      None
+      RSASSA-PSS-1024
+      RSASSA-PKCS1-v1_5-1024
+      DSA-1024
+      ECDSA-P192
+      RSASSA-PSS-2048
+      RSASSA-PKCS1-v1_5-2048
+      DSA-2048
+      ECDSA-P224
+      ECDSA-K233
+      ECDSA-B233
+      ECDSA-P256
+
+   .. attribute:: hash_type
+
+      The hash type used in the signature algorithm.
+
+      >>> print("\n".join([str(x[1]) for x in ndef.signature.SignatureRecord()._mapping_hash_type]))
+      SHA-256
+
+   .. attribute:: signature
+
+      The signature (if not specified by `signature_uri`).
+
+   .. attribute:: signature_uri
+
+      The uniform resource identifier for the signature (if not specified by
+      `signature`).
+
+   .. attribute:: certificate_format
+
+      The format of the certificates in the chain.
+
+      >>> print("\n".join([str(x[1]) for x in ndef.signature.SignatureRecord()._mapping_certificate_format]))
+      X.509
+      M2M
+
+   .. attribute:: certificate_store
+
+      A list of certificates in the certificate chain.
+
+   .. attribute:: certificate_uri
+
+      The uniform resource identifier for the next certificate in the
+      certificate chain.
+
+   This is default usage:
+
+   >>> signature_record = ndef.SignatureRecord(None, 'SHA-256', b'', '', 'X.509', [], '')
+
+   This is a full example creating records, signing them and verifying them:
+
+   >>> import ndef
+   >>> import io
+   >>> from cryptography.hazmat.backends import default_backend
+   >>> from cryptography.hazmat.primitives import hashes
+   >>> from cryptography.hazmat.primitives.asymmetric import ec
+   >>> from cryptography.hazmat.primitives.asymmetric import utils
+   >>> from cryptography.exceptions import InvalidSignature
+   >>> from asn1crypto.algos import DSASignature
+
+   >>> private_key = ec.generate_private_key(ec.SECP256K1(), default_backend())
+   >>> public_key = private_key.public_key()
+
+   >>> r1 = ndef.UriRecord("https://example.com")
+   >>> r2 = ndef.TextRecord("TEST")
+
+   >>> stream = io.BytesIO()
+   >>> records = [r1, r2, ndef.SignatureRecord("ECDSA-P256", "SHA-256")]
+   >>> encoder = ndef.message_encoder(records, stream)
+   >>> for _ in range(len(records) - 1): next(encoder)
+
+   >>> signature = private_key.sign(stream.getvalue(), ec.ECDSA(hashes.SHA256()))
+   >>> records[-1].signature = DSASignature.load(signature, strict=True).to_p1363()
+   >>> next(encoder)
+   >>> octets = stream.getvalue()
+
+   >>> records_verified = []
+   >>> records_to_verify = []
+   >>> known_types = {'urn:nfc:wkt:Sig': ndef.signature.SignatureRecord}
+   >>> for record in ndef.message_decoder(octets, known_types=known_types):
+   ...     if not record.type == 'urn:nfc:wkt:Sig':
+   ...         records_to_verify.append(record)
+   ...     else:
+   ...         stream_to_verify = io.BytesIO()
+   ...         encoder_to_verify = ndef.message_encoder(records_to_verify + [record], stream_to_verify)
+   ...         for _ in range(len(records_to_verify)): next(encoder_to_verify)
+   ...         try:
+   ...             public_key.verify(DSASignature.from_p1363(record.signature).dump(), stream_to_verify.getvalue(), ec.ECDSA(hashes.SHA256()))
+   ...             records_verified.extend(records_to_verify)
+   ...             records_to_verify = []
+   ...         except InvalidSignature:
+   ...             pass
+
+   >>> records_verified = list(ndef.message_decoder(b''.join(ndef.message_encoder(records_verified))))

--- a/docs/records/signature.rst
+++ b/docs/records/signature.rst
@@ -124,11 +124,11 @@ store and an option URI to the next certificate in the chain.
    >>> stream = io.BytesIO()
    >>> records = [r1, r2, ndef.SignatureRecord("ECDSA-P256", "SHA-256")]
    >>> encoder = ndef.message_encoder(records, stream)
-   >>> for _ in range(len(records) - 1): next(encoder)
+   >>> for _ in range(len(records) - 1): e=next(encoder)
 
    >>> signature = private_key.sign(stream.getvalue(), ec.ECDSA(hashes.SHA256()))
    >>> records[-1].signature = DSASignature.load(signature, strict=True).to_p1363()
-   >>> next(encoder)
+   >>> e=next(encoder)
    >>> octets = stream.getvalue()
 
    >>> records_verified = []
@@ -140,7 +140,7 @@ store and an option URI to the next certificate in the chain.
    ...     else:
    ...         stream_to_verify = io.BytesIO()
    ...         encoder_to_verify = ndef.message_encoder(records_to_verify + [record], stream_to_verify)
-   ...         for _ in range(len(records_to_verify)): next(encoder_to_verify)
+   ...         for _ in range(len(records_to_verify)): e=next(encoder_to_verify)
    ...         try:
    ...             public_key.verify(DSASignature.from_p1363(record.signature).dump(), stream_to_verify.getvalue(), ec.ECDSA(hashes.SHA256()))
    ...             records_verified.extend(records_to_verify)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,3 +24,4 @@ flake8            # syntax and style checks  "flake8 src/ tests/"
 tox               # run tests before push    "tox -c tox.ini"
 sphinx            # to create documentation  "(cd docs && amke html doctest)"
 sphinx-rtd-theme  # with the final layout    "firefox docs/_build/html/index.html"
+cryptography      # signature documentation

--- a/src/ndef/__init__.py
+++ b/src/ndef/__init__.py
@@ -98,6 +98,7 @@ else:
     from . import handover
     from . import bluetooth
     from . import wifi
+    from . import signature
 
 message_decoder = message.message_decoder
 message_encoder = message.message_encoder
@@ -118,6 +119,7 @@ WifiSimpleConfigRecord = wifi.WifiSimpleConfigRecord
 WifiPeerToPeerRecord = wifi.WifiPeerToPeerRecord
 BluetoothEasyPairingRecord = bluetooth.BluetoothEasyPairingRecord
 BluetoothLowEnergyRecord = bluetooth.BluetoothLowEnergyRecord
+SignatureRecord = signature.SignatureRecord
 
 # METADATA ####################################################################
 

--- a/src/ndef/signature.py
+++ b/src/ndef/signature.py
@@ -1,0 +1,353 @@
+# -*- coding: utf-8 -*-
+"""Decoding and encoding of the NDEF Signature Record.
+
+The NDEF Signature Record is a well-known record type defined by the NFC
+Forum. It contains three fields: a version field, a signature field and a
+certificate field.
+
+The version field is static. Currently this implementation only supports v2.0
+of the NDEF Signature Record.
+
+The signature field contains the signature type, the message hash type and
+either the signature itself or a URI to the signature.
+
+The certificate field contains the certificate format type, a certificate chain
+store and an option URI to the next certificate in the chain.
+
+"""
+from __future__ import absolute_import, division
+from .record import Record, GlobalRecord, convert
+from collections import namedtuple
+
+VersionTuple = namedtuple('Version', 'major, minor')
+
+class SignatureRecord(GlobalRecord):
+    """The SignatureRecord class decodes or encodes an NDEF Signature Record.
+
+    This is default usage:
+
+    >>> signature_record = ndef.SignatureRecord(None, 'SHA-256', b'', '', 'X.509', [], '')
+
+    This is a full example creating records, signing them and verifying them:
+
+    >>> import ndef
+    >>> import io
+    >>> from cryptography.hazmat.backends import default_backend
+    >>> from cryptography.hazmat.primitives import hashes
+    >>> from cryptography.hazmat.primitives.asymmetric import ec
+    >>> from cryptography.hazmat.primitives.asymmetric import utils
+    >>> from cryptography.exceptions import InvalidSignature
+    >>> from asn1crypto.algos import DSASignature
+
+    >>> private_key = ec.generate_private_key(ec.SECP256K1(), default_backend())
+    >>> public_key = private_key.public_key()
+
+    >>> r1 = ndef.UriRecord("https://example.com")
+    >>> r2 = ndef.TextRecord("TEST")
+
+    >>> stream = io.BytesIO()
+    >>> records = [r1, r2, ndef.SignatureRecord("ECDSA-P256", "SHA-256")]
+    >>> encoder = ndef.message_encoder(records, stream)
+    >>> for _ in range(len(records) - 1): next(encoder)
+
+    >>> signature = private_key.sign(stream.getvalue(), ec.ECDSA(hashes.SHA256()))
+    >>> records[-1].signature = DSASignature.load(signature, strict=True).to_p1363()
+    >>> next(encoder)
+    >>> octets = stream.getvalue()
+
+    >>> records_verified = []
+    >>> records_to_verify = []
+    >>> known_types = {'urn:nfc:wkt:Sig': ndef.signature.SignatureRecord}
+    >>> for record in ndef.message_decoder(octets, known_types=known_types):
+    ...     if not record.type == 'urn:nfc:wkt:Sig':
+    ...         records_to_verify.append(record)
+    ...     else:
+    ...         stream_to_verify = io.BytesIO()
+    ...         encoder_to_verify = ndef.message_encoder(records_to_verify + [record], stream_to_verify)
+    ...         for _ in range(len(records_to_verify)): next(encoder_to_verify)
+    ...         try:
+    ...             public_key.verify(DSASignature.from_p1363(record.signature).dump(), stream_to_verify.getvalue(), ec.ECDSA(hashes.SHA256()))
+    ...             records_verified.extend(records_to_verify)
+    ...             records_to_verify = []
+    ...         except InvalidSignature:
+    ...             pass
+
+    >>> records_verified = list(ndef.message_decoder(b''.join(ndef.message_encoder(records_verified))))
+
+    """
+    _type = 'urn:nfc:wkt:Sig'
+    _version = 0x20 # this class implements v2.0 of the Signature RTD
+    _mapping_signature_type = (
+        (0x00, None),
+        (0x01, "RSASSA-PSS-1024"),
+        (0x02, "RSASSA-PKCS1-v1_5-1024"),
+        (0x03, "DSA-1024"),
+        (0x04, "ECDSA-P192"),
+        (0x05, "RSASSA-PSS-2048"),
+        (0x06, "RSASSA-PKCS1-v1_5-2048"),
+        (0x07, "DSA-2048"),
+        (0x08, "ECDSA-P224"),
+        (0x09, "ECDSA-K233"),
+        (0x0a, "ECDSA-B233"),
+        (0x0b, "ECDSA-P256"),
+    )
+    _mapping_hash_type = (
+        (0x02, "SHA-256"),
+    )
+    _mapping_certificate_format = (
+        (0x00, "X.509"),
+        (0x01, "M2M"),
+    )
+
+    def __init__(self, signature_type=None, hash_type=None, signature=None, signature_uri=None, certificate_format=None, certificate_store=None, certificate_uri=None):
+        """Initialize the record with signature type, hash type, signature,
+        signature URI, certificate format, certificate store and/or certificate
+        URI. All parameters are optional. The default value is an empty
+        Signature record.
+
+        """
+        self.signature_type = signature_type
+        self.hash_type = hash_type if hash_type is not None else 'SHA-256'
+        self.signature = signature if signature is not None else b''
+        self.signature_uri = signature_uri if signature_uri is not None else ''
+        self.certificate_format = certificate_format if certificate_format is not None else 'X.509'
+        self._certificate_store = []
+        if isinstance(certificate_store, list):
+            for certificate in certificate_store:
+                self.add_certificate_to_store(certificate)
+        self.certificate_uri = certificate_uri if certificate_uri is not None else ''
+
+    @property
+    def version(self):
+        """Signature Record: Version Field (Version)"""
+        return VersionTuple(self._version >> 4, self._version & 0x0F)
+
+    @property
+    def signature_type(self):
+        """Signature Record: Signature Field (Signature Type)"""
+        return self._get_name_signature_type(self._signature_type)
+
+    @signature_type.setter
+    def signature_type(self, value):
+        self._signature_type = self._get_enum_signature_type(value)
+
+    def _get_enum_signature_type(self, value):
+        for enum, name in self._mapping_signature_type:
+            if value == name:
+                return enum
+        errstr = "{!r} does not have a known Signature Type mapping".format(value)
+        raise self._value_error(errstr)
+
+    def _get_name_signature_type(self, value):
+        for enum, name in self._mapping_signature_type:
+            if value == enum:
+                return name
+
+    @property
+    def hash_type(self):
+        """Signature Record: Signature Field (Hash Type)"""
+        return self._get_name_hash_type(self._hash_type)
+
+    @hash_type.setter
+    def hash_type(self, value):
+        self._hash_type = self._get_enum_hash_type(value)
+
+    def _get_enum_hash_type(self, value):
+        for enum, name in self._mapping_hash_type:
+            if value == name:
+                return enum
+        errstr = "{!r} does not have a known Hash Type mapping".format(value)
+        raise self._value_error(errstr)
+
+    def _get_name_hash_type(self, value):
+        for enum, name in self._mapping_hash_type:
+            if value == enum:
+                return name
+
+    @property
+    def signature(self):
+        """Signature Record: Signature Field (Signature)"""
+        return self._signature
+
+    @signature.setter
+    def signature(self, value):
+        if not isinstance(value, (bytes, bytearray)):
+            errstr = "signature may be bytes or bytearray, but not '{}'"
+            raise self._value_error(errstr, type(value).__name__)
+        if len(value) >= 2**16:
+            errstr = "signature cannot be more than 2^16 octets, got {}"
+            raise self._value_error(errstr, len(value))
+        if value and hasattr(self, '_signature_uri') and self._signature_uri:
+            errstr = "cannot set both signature and signature_uri"
+            raise self._value_error(errstr)
+        self._signature = value
+
+    @property
+    def signature_uri(self):
+        """Signature Record: Signature Field (Signature URI)"""
+        return self._signature_uri
+
+    @signature_uri.setter
+    @convert('value_to_unicode')
+    def signature_uri(self, value):
+        if len(value) >= 2**16:
+            errstr = "signature_uri cannot be more than 2^16 octets, got {}"
+            raise self._value_error(errstr, len(value))
+        if value and hasattr(self, '_signature') and self._signature:
+            errstr = "cannot set both signature and signature_uri"
+            raise self._value_error(errstr)
+        self._signature_uri = value
+
+    @property
+    def certificate_format(self):
+        """Signature Record: Certificate Chain Field (Certificate Format)"""
+        return self._get_name_certificate_format(self._certificate_format)
+
+    @certificate_format.setter
+    def certificate_format(self, value):
+        self._certificate_format = self._get_enum_certificate_format(value)
+
+    def _get_enum_certificate_format(self, value):
+        for enum, name in self._mapping_certificate_format:
+            if value == name:
+                return enum
+        errstr = "{!r} does not have a known Certificate Format mapping".format(value)
+        raise self._value_error(errstr)
+
+    def _get_name_certificate_format(self, value):
+        for enum, name in self._mapping_certificate_format:
+            if value == enum:
+                return name
+
+    @property
+    def certificate_store(self):
+        """Signature Record: Certificate Chain Field (Certificate Store)"""
+        return self._certificate_store
+
+    def add_certificate_to_store(self, value):
+        if not isinstance(value, (bytes, bytearray)):
+            errstr = "certificate may be bytes or bytearray, but not '{}'"
+            raise self._value_error(errstr, type(value).__name__)
+        if len(value) >= 2**16:
+            errstr = "certificate cannot be more than 2^16 octets, got {}"
+            raise self._value_error(errstr, len(value))
+        if len(self._certificate_store)+1 >= 2**4:
+            errstr = "certificate store cannot hold more than 2^4 certificates, got {}"
+            raise self._value_error(errstr, len(self._certificate_store)+1)
+        self._certificate_store.append(value)
+
+    @property
+    def certificate_uri(self):
+        """Signature Record: Certificate Chain Field (Certificate URI)"""
+        return self._certificate_uri
+
+    @certificate_uri.setter
+    @convert('value_to_unicode')
+    def certificate_uri(self, value):
+        self._certificate_uri = value
+
+    def __format__(self, format_spec):
+        if format_spec == 'args':
+            s = ("{r.signature_type!r}, {r.hash_type!r}, {r.signature!r}, "
+                 "{r.signature_uri!r}, {r.certificate_format}, "
+                 "{r.certificate_store!r}, {r.certificate_uri!r}")
+            return s.format(r=self)
+
+        if format_spec == 'data':
+            s = ["Signature RTD '{r.version}'"]
+            if self.signature:
+                s.append("Signature Type '{r.signature_type}'")
+                s.append("Hash Type '{r.hash_type}'")
+                #s.append("Signature '{r.signature}'")
+            if self.signature_uri:
+                s.append("Signature URI '{r.signature_uri}'")
+            if self.certificate_store:
+                s.append("Certificate Format '{r.certificate_format}'")
+                #s.append(" ".join(["Certificate '{}'".format(c) for c in self.certificate_store]))
+            if self.certificate_uri:
+                self.append("Certificate URI '{r.certificate_uri}'")
+            return ' '.join(s).format(r=self)
+
+        return super(SignatureRecord, self).__format__(format_spec)
+
+    def _encode_payload(self):
+
+        # Version Field
+        VERSION = self._encode_struct('B', self._version)
+
+        # Signature Field
+        SUP = 0b10000000 if self.signature_uri else 0
+        SST = self._signature_type & 0b01111111
+        SHT = self._hash_type
+        if self.signature_uri:
+            SIGURI = self.signature_uri.encode('utf-8')
+        else:
+            SIGURI = self.signature
+        SIGNATURE = self._encode_struct('BBB+', SUP|SST, SHT, SIGURI)
+
+        # Certificate Field
+        CUP = 0b10000000 if self.certificate_uri else 0
+        CCF = (self._certificate_format << 4) & 0b01110000
+        CNC = len(self.certificate_store) & 0b00001111
+        CST = b''
+        for certificate in self._certificate_store:
+            CST += self._encode_struct('B+', certificate)
+        CERTURI = self._certificate_uri.encode('utf-8')
+        CERTIFICATE = self._encode_struct('BsB+', CUP|CCF|CNC, CST, CERTURI)
+
+        return VERSION + SIGNATURE + CERTIFICATE
+
+    _decode_min_payload_length = 7
+
+    @classmethod
+    def _decode_payload(cls, octets, errors):
+        # Called from Record._decode with the PAYLOAD of an NDEF Signature
+        # Record. Returns a new SignatureRecord instance initialized with
+        # the decoded data fields. Raises a DecodeError if any of the
+        # decoding steps failed.
+
+        VERSION, SUP_SST, SHT, SIGURI, CUP_CCF_CNC, CST, CERTURI = cls._decode_struct('BBBB+BsB+', octets)
+
+        # Version Field
+        if not VERSION == cls._version and errors == 'strict':
+            errmsg = "decoding of version {} is not supported"
+            raise cls._decode_error(errmsg.format(VERSION))
+
+        # Signature Field
+        signature_uri_present = SUP_SST & 0b10000000
+        signature_type = cls._get_name_signature_type(SignatureRecord(), SUP_SST & 0b01111111)
+        hash_type = cls._get_name_hash_type(SignatureRecord(), SHT)
+        if signature_uri_present:
+            signature = None
+            try:
+                signature_uri = SIGURI.decode('utf-8')
+            except UnicodeDecodeError:
+                raise cls._decode_error("Signature URI field is not valid UTF-8 data")
+            if any([ord(char) <= 31 for char in signature_uri]):
+                raise cls._decode_error("Signature URI field contains invalid characters")
+        else:
+            signature_uri = None
+            signature = SIGURI
+
+        # Certificate Field
+        certificate_uri_present = CUP_CCF_CNC & 0b10000000
+        certificate_format = cls._get_name_certificate_format(SignatureRecord(), (CUP_CCF_CNC & 0b01110000) >> 4)
+        certificate_number_of_certificates = CUP_CCF_CNC & 0b00001111
+        certificate_store = []
+        for certificate_number in range(certificate_number_of_certificates):
+            certificate_store[certificate_number] = cls._decode_struct('B+', CST)
+            CST = CST[len(certificate_store[certificate_number]):]
+        if certificate_uri_present:
+            try:
+                certificate_uri = CERTURI.decode('utf-8')
+            except UnicodeDecodeError:
+                raise cls._decode_error("Certificate URI field is not valid UTF-8 data")
+            if any([ord(char) <= 31 for char in certificate_uri]):
+                raise cls._decode_error("Certificate URI field contains invalid characters")
+        else:
+            certificate_uri = None
+
+        return cls(signature_type, hash_type, signature, signature_uri, certificate_format, certificate_store, certificate_uri)
+
+
+Record.register_type(SignatureRecord)

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division
+
+import ndef
+import _test_record_base
+
+
+def pytest_generate_tests(metafunc):
+    _test_record_base.generate_tests(metafunc)
+
+
+class TestSignatureRecord(_test_record_base._TestRecordBase):
+    RECORD = ndef.signature.SignatureRecord
+    ATTRIB = ("signature_type, hash_type, signature, signature_uri,"
+              "certificate_format, certificate_store, certificate_uri")
+#signature_type=None, hash_type="SHA-256", signature=None, signature_uri=None, certificate_format="X.509", certificate_store=[], certificate_uri=None
+    test_init_args_data = [
+        ((),
+         (None, 'SHA-256', b'', '', 'X.509', [], '')),
+    ]
+    test_init_kwargs_data = [
+        ((None, None, None, None, None, None, None),
+         "signature_type=None, hash_type=None, signature=None, signature_uri=None, certificate_format=None, certificate_store=None, certificate_uri=None"),
+    ]
+    test_init_fail_data = [
+        ((None, None, None, 1, None, None, None),
+         ".signature_uri accepts str or bytes, but not int"),
+        ((None, None, None, None, None, None, 1),
+         ".certificate_uri accepts str or bytes, but not int"),
+        ((None, None, 1, None, None, None, None),
+         ".signature may be bytes or bytearray, but not 'int'"),
+        ((None, None, (2**16)*b'1', None, None, None, None),
+         ".signature cannot be more than 2^16 octets, got 65536"),
+        ((None, None, b'1', '1', None, None, None),
+         " cannot set both signature and signature_uri"),
+        ((None, None, None, (2**16)*'1', None, None, None),
+         ".signature_uri cannot be more than 2^16 octets, got 65536"),
+        ((None, None, None, None, None, [1], None),
+         " certificate may be bytes or bytearray, but not 'int'"),
+        ((None, None, None, None, None, [(2**16)*b'1'], None),
+         " certificate cannot be more than 2^16 octets, got 65536"),
+        ((None, None, None, None, None, [b'1' for x in range(2**4)], None),
+         " certificate store cannot hold more than 2^4 certificates, got 16"),
+    ]
+    test_decode_valid_data = [
+        ('20000200000000',
+         (None, 'SHA-256', b'', '', 'X.509', [], '')),
+        ('200b02473045022100a410c28fd9437fd24f6656f121e62bcc5f65e36257f5faadf68e3e83d40d481a0220335b1dff8d6fe722fcf7018be9684d2de5670b256fdfc02aa25bdae16f624b80000000',
+         ('ECDSA-P256', 'SHA-256', b'0E\x02!\x00\xa4\x10\xc2\x8f\xd9C\x7f\xd2OfV\xf1!\xe6+\xcc_e\xe3bW\xf5\xfa\xad\xf6\x8e>\x83\xd4\rH\x1a\x02 3[\x1d\xff\x8do\xe7"\xfc\xf7\x01\x8b\xe9hM-\xe5g\x0b%o\xdf\xc0*\xa2[\xda\xe1obK\x80', '', 'X.509', [], '')),
+    ]
+    test_decode_error_data = [
+        ('10000200000000', "decoding of version 16 is not supported"),
+    ]
+    test_decode_relax = None
+    test_encode_error = None
+    test_format_args_data = [
+        ((),
+         "None, 'SHA-256', b'', '', X.509, [], ''"),
+        (('ECDSA-P256', 'SHA-256', b'0E\x02!\x00\xa4\x10\xc2\x8f\xd9C\x7f\xd2OfV\xf1!\xe6+\xcc_e\xe3bW\xf5\xfa\xad\xf6\x8e>\x83\xd4\rH\x1a\x02 3[\x1d\xff\x8do\xe7"\xfc\xf7\x01\x8b\xe9hM-\xe5g\x0b%o\xdf\xc0*\xa2[\xda\xe1obK\x80', '', 'X.509', [], ''),
+         '\'ECDSA-P256\', \'SHA-256\', b\'0E\\x02!\\x00\\xa4\\x10\\xc2\\x8f\\xd9C\\x7f\\xd2OfV\\xf1!\\xe6+\\xcc_e\\xe3bW\\xf5\\xfa\\xad\\xf6\\x8e>\\x83\\xd4\\rH\\x1a\\x02 3[\\x1d\\xff\\x8do\\xe7"\\xfc\\xf7\\x01\\x8b\\xe9hM-\\xe5g\\x0b%o\\xdf\\xc0*\\xa2[\\xda\\xe1obK\\x80\', \'\', X.509, [], \'\''),
+    ]
+    test_format_str_data = [
+        (
+            (),
+            "NDEF Signature Record ID '' Signature RTD 'Version(major=2, minor=0)'"
+        ), (
+            ('ECDSA-P256', 'SHA-256', b'0E\x02!\x00\xa4\x10\xc2\x8f\xd9C\x7f\xd2OfV\xf1!\xe6+\xcc_e\xe3bW\xf5\xfa\xad\xf6\x8e>\x83\xd4\rH\x1a\x02 3[\x1d\xff\x8do\xe7"\xfc\xf7\x01\x8b\xe9hM-\xe5g\x0b%o\xdf\xc0*\xa2[\xda\xe1obK\x80', '', 'X.509', [], ''),
+            'NDEF Signature Record ID \'\' Signature RTD \'Version(major=2, minor=0)\' Signature Type \'ECDSA-P256\' Hash Type \'SHA-256\''
+        )
+    ]

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -14,14 +14,17 @@ class TestSignatureRecord(_test_record_base._TestRecordBase):
     RECORD = ndef.signature.SignatureRecord
     ATTRIB = ("signature_type, hash_type, signature, signature_uri,"
               "certificate_format, certificate_store, certificate_uri")
-#signature_type=None, hash_type="SHA-256", signature=None, signature_uri=None, certificate_format="X.509", certificate_store=[], certificate_uri=None
+# signature_type=None, hash_type="SHA-256", signature=None, signature_uri=None,
+# certificate_format="X.509", certificate_store=[], certificate_uri=None
     test_init_args_data = [
         ((),
          (None, 'SHA-256', b'', '', 'X.509', [], '')),
     ]
     test_init_kwargs_data = [
         ((None, None, None, None, None, None, None),
-         "signature_type=None, hash_type=None, signature=None, signature_uri=None, certificate_format=None, certificate_store=None, certificate_uri=None"),
+         ("signature_type=None, hash_type=None, signature=None, "
+          "signature_uri=None, certificate_format=None, "
+          "certificate_store=None, certificate_uri=None")),
     ]
     test_init_fail_data = [
         ((None, None, None, 1, None, None, None),
@@ -42,12 +45,19 @@ class TestSignatureRecord(_test_record_base._TestRecordBase):
          " certificate cannot be more than 2^16 octets, got 65536"),
         ((None, None, None, None, None, [b'1' for x in range(2**4)], None),
          " certificate store cannot hold more than 2^4 certificates, got 16"),
+
     ]
     test_decode_valid_data = [
         ('20000200000000',
          (None, 'SHA-256', b'', '', 'X.509', [], '')),
-        ('200b02473045022100a410c28fd9437fd24f6656f121e62bcc5f65e36257f5faadf68e3e83d40d481a0220335b1dff8d6fe722fcf7018be9684d2de5670b256fdfc02aa25bdae16f624b80000000',
-         ('ECDSA-P256', 'SHA-256', b'0E\x02!\x00\xa4\x10\xc2\x8f\xd9C\x7f\xd2OfV\xf1!\xe6+\xcc_e\xe3bW\xf5\xfa\xad\xf6\x8e>\x83\xd4\rH\x1a\x02 3[\x1d\xff\x8do\xe7"\xfc\xf7\x01\x8b\xe9hM-\xe5g\x0b%o\xdf\xc0*\xa2[\xda\xe1obK\x80', '', 'X.509', [], '')),
+        (('200b02473045022100a410c28fd9437fd24f6656f121e62bcc5f65e36257f5faadf'
+          '68e3e83d40d481a0220335b1dff8d6fe722fcf7018be9684d2de5670b256fdfc02a'
+          'a25bdae16f624b80000000'),
+         ('ECDSA-P256', 'SHA-256',
+          (b'0E\x02!\x00\xa4\x10\xc2\x8f\xd9C\x7f\xd2OfV\xf1!\xe6+\xcc_e\xe3bW'
+           b'\xf5\xfa\xad\xf6\x8e>\x83\xd4\rH\x1a\x02 3[\x1d\xff\x8do\xe7"\xfc'
+           b'\xf7\x01\x8b\xe9hM-\xe5g\x0b%o\xdf\xc0*\xa2[\xda\xe1obK\x80'),
+          '', 'X.509', [], '')),
     ]
     test_decode_error_data = [
         ('10000200000000', "decoding of version 16 is not supported"),
@@ -57,15 +67,27 @@ class TestSignatureRecord(_test_record_base._TestRecordBase):
     test_format_args_data = [
         ((),
          "None, 'SHA-256', b'', '', X.509, [], ''"),
-        (('ECDSA-P256', 'SHA-256', b'0E\x02!\x00\xa4\x10\xc2\x8f\xd9C\x7f\xd2OfV\xf1!\xe6+\xcc_e\xe3bW\xf5\xfa\xad\xf6\x8e>\x83\xd4\rH\x1a\x02 3[\x1d\xff\x8do\xe7"\xfc\xf7\x01\x8b\xe9hM-\xe5g\x0b%o\xdf\xc0*\xa2[\xda\xe1obK\x80', '', 'X.509', [], ''),
-         '\'ECDSA-P256\', \'SHA-256\', b\'0E\\x02!\\x00\\xa4\\x10\\xc2\\x8f\\xd9C\\x7f\\xd2OfV\\xf1!\\xe6+\\xcc_e\\xe3bW\\xf5\\xfa\\xad\\xf6\\x8e>\\x83\\xd4\\rH\\x1a\\x02 3[\\x1d\\xff\\x8do\\xe7"\\xfc\\xf7\\x01\\x8b\\xe9hM-\\xe5g\\x0b%o\\xdf\\xc0*\\xa2[\\xda\\xe1obK\\x80\', \'\', X.509, [], \'\''),
+        (('ECDSA-P256', 'SHA-256',
+          (b'0E\x02!\x00\xa4\x10\xc2\x8f\xd9C\x7f\xd2OfV\xf1!\xe6+\xcc_e\xe3bW'
+           b'\xf5\xfa\xad\xf6\x8e>\x83\xd4\rH\x1a\x02 3[\x1d\xff\x8do\xe7"\xfc'
+           b'\xf7\x01\x8b\xe9hM-\xe5g\x0b%o\xdf\xc0*\xa2[\xda\xe1obK\x80'),
+          '', 'X.509', [], ''),
+         ('\'ECDSA-P256\', \'SHA-256\', b\'0E\\x02!\\x00\\xa4\\x10\\xc2\\x8f\\'
+          'xd9C\\x7f\\xd2OfV\\xf1!\\xe6+\\xcc_e\\xe3bW\\xf5\\xfa\\xad\\xf6\\x8'
+          'e>\\x83\\xd4\\rH\\x1a\\x02 3[\\x1d\\xff\\x8do\\xe7"\\xfc\\xf7\\x01'
+          '\\x8b\\xe9hM-\\xe5g\\x0b%o\\xdf\\xc0*\\xa2[\\xda\\xe1obK\\x80\', '
+          '\'\', X.509, [], \'\'')),
     ]
     test_format_str_data = [
-        (
-            (),
-            "NDEF Signature Record ID '' Signature RTD 'Version(major=2, minor=0)'"
-        ), (
-            ('ECDSA-P256', 'SHA-256', b'0E\x02!\x00\xa4\x10\xc2\x8f\xd9C\x7f\xd2OfV\xf1!\xe6+\xcc_e\xe3bW\xf5\xfa\xad\xf6\x8e>\x83\xd4\rH\x1a\x02 3[\x1d\xff\x8do\xe7"\xfc\xf7\x01\x8b\xe9hM-\xe5g\x0b%o\xdf\xc0*\xa2[\xda\xe1obK\x80', '', 'X.509', [], ''),
-            'NDEF Signature Record ID \'\' Signature RTD \'Version(major=2, minor=0)\' Signature Type \'ECDSA-P256\' Hash Type \'SHA-256\''
-        )
+        ((),
+         ("NDEF Signature Record ID '' Signature RTD "
+          "'Version(major=2, minor=0)'")),
+        (('ECDSA-P256', 'SHA-256',
+          (b'0E\x02!\x00\xa4\x10\xc2\x8f\xd9C\x7f\xd2OfV\xf1!\xe6+\xcc_e\xe3bW'
+           b'\xf5\xfa\xad\xf6\x8e>\x83\xd4\rH\x1a\x02 3[\x1d\xff\x8do\xe7"\xfc'
+           b'\xf7\x01\x8b\xe9hM-\xe5g\x0b%o\xdf\xc0*\xa2[\xda\xe1obK\x80'),
+          '', 'X.509', [], ''),
+         ('NDEF Signature Record ID \'\' Signature RTD '
+          '\'Version(major=2, minor=0)\' Signature Type '
+          '\'ECDSA-P256\' Hash Type \'SHA-256\'')),
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ setenv =
 deps =
     sphinx
 commands =
+    pip install cryptography
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
     python -m doctest README.rst

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,8 @@ setenv =
     PYTHONHASHSEED = 0
 deps =
     sphinx
+    cryptography
 commands =
-    pip install cryptography
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     sphinx-build -W -b doctest -d {envtmpdir}/doctrees docs docs/_build/html
     python -m doctest README.rst


### PR DESCRIPTION
I'm adding NDEF Signature Record to this library.

I'm currently struggling with an elegant way to calculate the signature _during_ message encoding; but because `message._message_encoder` is a generator, there isn't a way to "peek" at the current state of the message. Therefore one has to summon the encoder multiple times to achieve the desired results (see script below).

Can anyone think of a better way to do this? Should I modify `message.py` to make integration easier?

Currently this is the script that I am using the generate Signature Records:

```python
import os,sys,inspect
currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
parentdir = os.path.dirname(currentdir)
sys.path.insert(0,parentdir)
import ndef
from cryptography.hazmat.backends import default_backend
from cryptography.hazmat.primitives import hashes
from cryptography.hazmat.primitives.asymmetric import ec
from cryptography.hazmat.primitives.asymmetric import utils
from asn1crypto.algos import DSASignature
from more_itertools import peekable
private_key = ec.generate_private_key(ec.SECP256K1(), default_backend())

r1=ndef.UriRecord("https://example.com")
r2=ndef.TextRecord("TEST")
encoder = ndef.message_encoder()
results = list()
encoder.send(None)
encoder.send(r1)
results.append(encoder.send(r2))
results.append(encoder.send(ndef.SignatureRecord()))
print(results)
msg_to_sign = b''.join(results)
print(msg_to_sign)
signature = private_key.sign(msg_to_sign,ec.ECDSA(hashes.SHA256()))
signature_p1363 = DSASignature.load(signature, strict=True).to_p1363()
r3=ndef.SignatureRecord("ECDSA-P256", "SHA-256", signature_p1363)
encoder = ndef.message_encoder()
results = list()
encoder.send(None)
encoder.send(r1)
results.append(encoder.send(r2))
results.append(encoder.send(r3))
results.append(encoder.send(None))
m=b''.join(results)
print(m)

d=ndef.message_decoder(m)
d1=next(d)
d2=next(d)
d3=next(d)

encoder = ndef.message_encoder()
results = list()
encoder.send(None)
encoder.send(r1)
results.append(encoder.send(r2))
results.append(encoder.send(ndef.SignatureRecord()))
print(results)
msg_to_verify = b''.join(results)

public_key = private_key.public_key()
verification = public_key.verify(DSASignature.from_p1363(d3.signature).dump(),msg_to_verify,ec.ECDSA(hashes.SHA256()))
```